### PR TITLE
[Travis] Switch to Ubuntu 18.04 Bionic and add workaround for urdf_parser_py regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update; fi 
   # Save the url of the repository and the user-name of the committ author
   - export CURRENT_REPOSITORY_URL=`git remote get-url origin`
-  - COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"
+  - COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>')"
   # Start in the parent directory of icub-model-generator
   - cd ..
   - sudo apt-get install  --assume-yes --force-yes python-lxml python-yaml python-numpy python-setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: bionic
 language: cpp
-cache: ccache
+#cache: ccache
 
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ addons:
       - libeigen3-dev
       - libgsl0-dev
       - libtinyxml-dev
+      - liborocos-kdl
+      - libconsole-bridge-dev
+      - liburdfdom-headers-dev
+      - liburdfdom-dev 
 
 env:
   global:
@@ -73,38 +77,6 @@ before_script:
   - mkdir build
   - cd build
   - cmake ..
-  - sudo cmake --build . --target install
-  - cd ../..
-  ## orocos_kdl
-  - git clone https://github.com/orocos/orocos_kinematics_dynamics
-  - cd orocos_kinematics_dynamics/orocos_kdl
-  - mkdir build
-  - cd build
-  - cmake ..
-  - sudo cmake --build . --target install
-  - cd ../../..
-  ## console_bridge
-  - git clone https://github.com/ros/console_bridge
-  - cd console_bridge
-  - mkdir build
-  - cd build
-  - cmake ..
-  - sudo cmake --build . --target install
-  - cd ../..
-  # urdfdom_headers
-  - git clone https://github.com/ros/urdfdom_headers
-  - cd urdfdom_headers
-  - mkdir build
-  - cd build
-  - cmake ..
-  - sudo cmake --build . --target install
-  - cd ../..
-  # urdfdom
-  - git clone https://github.com/ros/urdfdom
-  - cd urdfdom
-  - mkdir build
-  - cd build
-  - cmake  ..
   - sudo cmake --build . --target install
   - cd ../..
   ## idyntree

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,19 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: cpp
 cache: ccache
 
 
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
     packages:
-      # gcc
-      - gcc-5
-      - g++-5
       # build tools
+      - build-essentials
       - cmake3
       # libraries
       - libace-dev
       - libboost-dev
+      - libeigen3-dev
       - libgsl0-dev
       - libtinyxml-dev
 
@@ -31,11 +27,7 @@ env:
     - BOT_USER_NAME="LOC2Bot"
 
 before_script:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo add-apt-repository ppa:nschloe/eigen-backports -y; fi 
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update; fi 
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libeigen3-dev; fi
-  # Force gcc-5
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then if [ "$CC" == "gcc" ]; then export CC=gcc-5; export CXX=g++-5; fi; fi
   # Save the url of the repository and the user-name of the committ author
   - export CURRENT_REPOSITORY_URL=`git remote get-url origin`
   - COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"
@@ -48,6 +40,8 @@ before_script:
   # install urdf_parser_py and save the last commit SHA1 hash
   - git clone $URDF_PARSER_PY_REPOSITORY_URL
   - cd urdf_parser_py
+  # workaround for https://github.com/robotology/simmechanics-to-urdf/issues/36
+  - git checkout 31474b9baaf7c3845b40e5a9aa87d5900a2282c3 
   - export URDF_PARSER_PY_COMMIT=`git rev-parse HEAD`
   - sudo python setup.py install
   - cd ../
@@ -132,10 +126,10 @@ before_script:
   - sudo cmake --build . --target install
   - cd ../..
   # Install sdformat
-  - sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu trusty main" > /etc/apt/sources.list.d/gazebo-latest.list'
+  - sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu bionic main" > /etc/apt/sources.list.d/gazebo-latest.list'
   - wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get install --assume-yes --force-yes libsdformat4-dev
+  - sudo apt-get install --assume-yes --force-yes libsdformat6-dev
   # Prepare icub-model-generator build
   - cd icub-model-generator
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - libeigen3-dev
       - libgsl0-dev
       - libtinyxml-dev
-      - liborocos-kdl
+      - liborocos-kdl-dev
       - libconsole-bridge-dev
       - liburdfdom-headers-dev
       - liburdfdom-dev 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
   apt:
     packages:
       # build tools
-      - build-essentials
-      - cmake3
+      - build-essential
+      - cmake
       # libraries
       - libace-dev
       - libboost-dev

--- a/dh/generator/CMakeLists.txt
+++ b/dh/generator/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(YCM REQUIRED)
 find_package(YARP 3.0 REQUIRED COMPONENTS OS dev sig math gsl)
 find_package(ICUB REQUIRED)
 
+find_package(console_bridge REQUIRED)
 find_package(urdfdom REQUIRED)
 find_package(orocos_kdl REQUIRED)
 find_package(Eigen3 REQUIRED)


### PR DESCRIPTION
See  https://github.com/robotology/simmechanics-to-urdf/issues/36 and https://github.com/ros/urdf_parser_py/pull/47 for more info on the regression. 
See https://docs.travis-ci.com/user/reference/bionic/ for the Ubuntu 18.04 Bionic. 

If this is successful, hopefully it would simplify reproducing the Travis failure in https://travis-ci.org/robotology/icub-model-generator/builds/570949195 mentioned in https://github.com/robotology/icub-model-generator/pull/113#issuecomment-522576137  .