### PR TITLE
Fix Travis build by using ycm v0.10.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,6 +142,8 @@ before_script:
   # ycm
   - git clone https://github.com/robotology/ycm.git
   - cd ycm
+  # ycm v0.10.4 is the latest release compatible with CMake 3.5 currently used in
+  # travis CI that still uses Ubuntu 14.04
   - git checkout v0.10.4
   - mkdir build
   - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,6 +142,7 @@ before_script:
   # ycm
   - git clone https://github.com/robotology/ycm.git
   - cd ycm
+  - git checkout v0.10.4
   - mkdir build
   - cd build
   - cmake ..


### PR DESCRIPTION
The PR https://github.com/robotology/icub-model-generator/pull/122 did not work after the merge due to this. 