### PR TITLE
Use preserveFixedJoint to convert URDF fixed joints to SDF fixed joints

### DIFF
--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -970,26 +970,38 @@ XMLBlobs:
         </joint>
   - |
         <gazebo reference="r_arm_ft_sensor">
+          <preserveFixedJoint>true</preserveFixedJoint>
+          <!-- For compatibility with SDFormat < 4.4 -->
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
   - |
         <gazebo reference="l_arm_ft_sensor">
+          <preserveFixedJoint>true</preserveFixedJoint>
+          <!-- For compatibility with SDFormat < 4.4 -->
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
   - |
         <gazebo reference="r_leg_ft_sensor">
+          <preserveFixedJoint>true</preserveFixedJoint>
+          <!-- For compatibility with SDFormat < 4.4 -->
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
   - |
         <gazebo reference="l_leg_ft_sensor">
+          <preserveFixedJoint>true</preserveFixedJoint>
+          <!-- For compatibility with SDFormat < 4.4 -->
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
   - |
         <gazebo reference="r_foot_ft_sensor">
+          <preserveFixedJoint>true</preserveFixedJoint>
+          <!-- For compatibility with SDFormat < 4.4 -->
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
   - |
         <gazebo reference="l_foot_ft_sensor">
+          <preserveFixedJoint>true</preserveFixedJoint>
+          <!-- For compatibility with SDFormat < 4.4 -->
           <disableFixedJointLumping>true</disableFixedJointLumping>
         </gazebo>
   - |


### PR DESCRIPTION
Fix https://github.com/robotology/icub-models/issues/25 .
Without this fix, the FT sensors fixed joints were converted in Gazebo  to revolute joint with max and min position limits set to 0.0 .

See https://bitbucket.org/osrf/sdformat/pull-requests/352/add-preservefixedjoint-option-to-the-urdf/diff for the reason why `disableFixedJointLumping` is kept.