### PR TITLE
Compatibility with iDynTree 1.x and 2.x

### DIFF
--- a/simmechanics/scripts/generate_taxels_3d_positions.py
+++ b/simmechanics/scripts/generate_taxels_3d_positions.py
@@ -3,7 +3,16 @@
 
 # Import yarp & iDynTree python bindings 
 import yarp
-import iDynTree
+
+# See https://github.com/robotology/idyntree/pull/733#issuecomment-689508234
+import pkg_resources
+
+try:
+    pkg_resources.get_distribution('iDynTree')
+except pkg_resources.DistributionNotFound:
+    from idyntree import iDynTree
+else:
+    import iDynTree
 
 # Import argparse & numpy & scipy
 import argparse

--- a/simmechanics/scripts/generate_taxels_3d_positions.py
+++ b/simmechanics/scripts/generate_taxels_3d_positions.py
@@ -10,7 +10,7 @@ import pkg_resources
 try:
     pkg_resources.get_distribution('iDynTree')
 except pkg_resources.DistributionNotFound:
-    from idyntree import iDynTree
+    import idyntree.bindings as iDynTree
 else:
     import iDynTree
 


### PR DESCRIPTION
This will ensure that this scripts is broken due to the changes in iDynTree 2.x , see https://github.com/robotology/idyntree/pull/733 .