### PR TITLE
Clarify meaning of plus in model naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Both generation pipelines are still in `a work in progress` state, and several i
 |:--------------------:|:------------:|:-------------------------------:|
 | `iCubDarmstadt01`    | simmechanics | v2.5 without backpack           |
 | `iCubGazeboV2_5`     | simmechanics | v2.5 with backpack, joint damping, and inertias of some links modified to run smoothly in Gazebo |
-| `iCubGazeboV2_5_plus`| simmechanics | v2.5+ with backpack, joint damping, and inertias of some links modified to run smoothly in Gazebo |
+| `iCubGazeboV2_5_plus`| simmechanics | v2.5 + [KIT_007](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) with backpack, joint damping, and inertias of some links modified to run smoothly in Gazebo |
 | `iCubGenova01`       | simmechanics | v2.5 without backpack           |
-| `iCubGenova02`       | simmechanics | v2.5+   with backpack           |
+| `iCubGenova02`       | simmechanics | v2.5 + [KIT_007](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) with backpack           |
 | `iCubGenova03`       | dh           | v2 with legs v1 and feet v2.5   |
 | `iCubGenova04`       | simmechanics | v2.5   with backpack            |
-| `iCubGenova04_plus`  | simmechanics | v2.5+   with backpack           |
+| `iCubGenova04_plus`  | simmechanics | v2.5 + [KIT_007](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) with backpack           |
 | `iCubLisboa01`       | dh           | v1 with head v2                 |
 | `iCubNancy01`        | dh           | v2.5 with arms v1 and head v2   |
 | `iCubParis01`        | dh           | v1 with feet v2.5               |


### PR DESCRIPTION
The "incline" sole is now codified as the [`KIT_007`](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) iCub's upgrade kit, so let's clarify that in the user-facing documentation. 