### PR TITLE
Push new changes to icub-models devel branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT="master"
     - TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT="https://github.com/robotology/icub-model-generator.git"
     - BOT_USER_NAME="LOC2Bot"
+    - ICUB_MODELS_BRANCH="devel"
 
 # For all dependencies, we use fixed releases to avoid regression due to
 # changes in the dependencies. In particular, we use the latest released
@@ -60,7 +61,7 @@ before_script:
   - sudo python setup.py install
   - cd ../
   # copy output folders and add the environment variable
-  - git clone https://$DEPLOYMENT_REPOSITORY_TOKEN
+  - git clone -b $ICUB_MODELS_BRANCH https://$DEPLOYMENT_REPOSITORY_TOKEN
   - cd icub-models
   - export ICUB_MODELS_SOURCE_DIR=`pwd`
   - cd ../
@@ -170,7 +171,7 @@ after_success:
       git commit -a -m "Automatic build. Travis build:$TRAVIS_BUILD_NUMBER" -m "icub-model-generator commit:$TRAVIS_COMMIT"
       -m "urdf_parser_py commit:$URDF_PARSER_PY_COMMIT" -m "simmechanics-to-urdf commit:$SIMMECHANICS_TO_URDF_COMMIT"
       -m "yarp commit:$YARP_COMMIT" -m "icub-main commit:$ICUB_MAIN_COMMIT" -m "idyntree commit:$IDYNTREE_COMMIT" --author "$COMMIT_AUTHOR";
-      git push --set-upstream --quiet origin master;
+      git push --set-upstream --quiet origin $ICUB_MODELS_BRANCH;
     fi
 
 notifications:


### PR DESCRIPTION
As discussed in https://github.com/robotology/icub-model-generator/issues/124, it could make sense to let this repo push directly to the `devel` branch of `icub-models`, and then merge the changes back in master when we do a release of icub-models. In a sense, the `devel` branch will be a sort of staging branch. 