### PR TITLE
 Make the root_link the father of the base_link instead of the other way around

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT="master"
     - TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT="https://github.com/robotology/icub-model-generator.git"
     - BOT_USER_NAME="LOC2Bot"
+    - ICUB_MODELS_BRANCH="devel"
 
 # For all dependencies, we use fixed releases to avoid regression due to
 # changes in the dependencies. In particular, we use the latest released
@@ -60,7 +61,7 @@ before_script:
   - sudo python setup.py install
   - cd ../
   # copy output folders and add the environment variable
-  - git clone https://$DEPLOYMENT_REPOSITORY_TOKEN
+  - git clone -b $ICUB_MODELS_BRANCH https://$DEPLOYMENT_REPOSITORY_TOKEN
   - cd icub-models
   - export ICUB_MODELS_SOURCE_DIR=`pwd`
   - cd ../
@@ -170,7 +171,7 @@ after_success:
       git commit -a -m "Automatic build. Travis build:$TRAVIS_BUILD_NUMBER" -m "icub-model-generator commit:$TRAVIS_COMMIT"
       -m "urdf_parser_py commit:$URDF_PARSER_PY_COMMIT" -m "simmechanics-to-urdf commit:$SIMMECHANICS_TO_URDF_COMMIT"
       -m "yarp commit:$YARP_COMMIT" -m "icub-main commit:$ICUB_MAIN_COMMIT" -m "idyntree commit:$IDYNTREE_COMMIT" --author "$COMMIT_AUTHOR";
-      git push --set-upstream --quiet origin master;
+      git push --set-upstream --quiet origin $ICUB_MODELS_BRANCH;
     fi
 
 notifications:

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -944,7 +944,7 @@ XMLBlobs:
   - |
         <link name="base_link" />
   - |
-        <joint name="base_fixed_joint" type="fixed">
+        <joint name="base_link_fixed_joint" type="fixed">
           <origin xyz="0 0 0" rpy="0 -0 0" />
           <axis xyz="0 0 0" />
           <parent link="root_link" />

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -947,8 +947,8 @@ XMLBlobs:
         <joint name="base_fixed_joint" type="fixed">
           <origin xyz="0 0 0" rpy="0 -0 0" />
           <axis xyz="0 0 0" />
-          <parent link="base_link" />
-          <child link="root_link" />
+          <parent link="root_link" />
+          <child link="base_link" />
         </joint>
   - |
         <link name="l_foot_dh_frame"/>


### PR DESCRIPTION
This permits to avoid the Gazebo bug described in #140 . 
Furthermore, this will make sure that even after fixed joint lumping the link in Classic Gazebo will be called "root_link".

For an extensive rationale, see https://github.com/robotology/icub-model-generator/issues/140#issuecomment-700653608 .

This PR requires https://github.com/robotology/icub-model-generator/pull/141 to ensure that even if merge the changes will not reach directly the `master` branch. 
