### PR TITLE
Fix Travis CI for PRs coming from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,11 @@ env:
 before_script:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get update; fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libeigen3-dev; fi
-  # Save the url of the repository and the user-name of the committ author
-  - export CURRENT_REPOSITORY_URL=`git remote get-url origin`
-  - COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"
+  - if [[ $TRAVIS_BRANCH == $TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT && $CURRENT_REPOSITORY_URL == $TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT && $TRAVIS_EVENT_TYPE == push ]]; then
+      # Save the url of the repository and the user-name of the commit author
+      export CURRENT_REPOSITORY_URL=`git remote get-url origin`
+      COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"
+    fi
   # Start in the parent directory of icub-model-generator
   - cd ..
   - sudo apt-get install  --assume-yes --force-yes python-lxml python-yaml python-numpy python-setuptools


### PR DESCRIPTION
The line that was computing the COMMIT_AUTHOR variable is giving errors in some PRs,  but that is only useful for jobs that actually push a commit to the icub-models.