### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ on:
 env:
   URDF_PARSER_PY_REPOSITORY_URL: "https://github.com/ros/urdf_parser_py.git"
   SIMMECHANICS_TO_URDF_REPOSITORY_URL: "https://github.com/robotology/simmechanics-to-urdf.git"
-  DEPLOYMENT_REPOSITORY_TOKEN: "github.com/robotology/icub-models.git"
+  DEPLOYMENT_REPOSITORY: "robotology/icub-models"
   TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT: "refs/heads/test-gha-deploy"
   TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT: "https://github.com/robotology/icub-model-generator.git"
   BOT_USER_NAME: "LOC2Bot"
   ICUB_MODELS_BRANCH: "test-gha-deploy-devel"
-
+  ICUB_MODELS_SOURCE_DIR: ${{ env.github_workspace }}/icub-models
 jobs:
   build:
     runs-on: ubuntu-20.04
@@ -60,7 +60,7 @@ jobs:
         sudo python setup.py install
         cd ../
         # copy output folders and add the environment variable
-        git clone -b $ICUB_MODELS_BRANCH https://$DEPLOYMENT_REPOSITORY_TOKEN
+        git clone -b $ICUB_MODELS_BRANCH https://github.com/$DEPLOYMENT_REPOSITORY_TOKEN
         cd icub-models
         export ICUB_MODELS_SOURCE_DIR=`pwd`
         cd ../
@@ -168,9 +168,20 @@ jobs:
         echo "icub-main commit:$ICUB_MAIN_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
-    - name: Deploy models
+    - name: Commit Models
       if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
         cat ${GITHUB_WORKSPACE}/deploy_commit_message
         export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"
         cat $COMMIT_AUTHOR
+        cd $ICUB_MODELS_SOURCE_DIR
+        git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message --author "$COMMIT_AUTHOR"
+
+    - name: Push Models
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        directory: ${{ env.ICUB_MODELS_SOURCE_DIR }}
+        repository: ${{ env.DEPLOYMENT_REPOSITORY }}
+        branch: ${{ env.ICUB_MODELS_BRANCH }}
+        token: ${{ secrets.BOT_TRIGGER_ROBOTOLOGY_DOCUMENTATION }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
         export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $GITHUB_SHA)"
+        echo "Commit author is $COMMIT_AUTHOR"
         cd $ICUB_MODELS_SOURCE_DIR
         git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message --author "$COMMIT_AUTHOR"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Generate models
       run: |
         sudo apt-get update
-        sudo apt-get install libeigen3-dev 
+        sudo apt-get install libeigen3-dev libace-dev libboost-dev libgsl0-dev libtinyxml-dev libxml2-dev
         # Save the url of the repository and the user-name of the committ author
         export CURRENT_REPOSITORY_URL=`git remote get-url origin`
         # Start in the parent directory of icub-model-generator

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     - uses: actions/checkout@v2
    
     - name: ref
-      run: echo ${{ github.ref }}
+      run: echo "${{ github.ref }}"
     - name: event_name
       run: echo ${{ github.event_name }}
     - name: env_TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
-      run: echo ${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}
+      run: echo "${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}"
     - name: print_check
       run: echo ${{ github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
     # Print environment variables to simplify development and debugging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT: "https://github.com/robotology/icub-model-generator.git"
   BOT_USER_NAME: "LOC2Bot"
   ICUB_MODELS_BRANCH: "test-gha-deploy-devel"
-  ICUB_MODELS_SOURCE_DIR: "~/icub-models"
+  ICUB_MODELS_SOURCE_DIR: "/home/runner/work/icub-model-generator/icub-model-generator/icub-models"
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         sudo python setup.py install
         cd ../
         # copy output folders and add the environment variable
-        git clone -b $ICUB_MODELS_BRANCH https://github.com/$DEPLOYMENT_REPOSITORY_TOKEN
+        git clone -b $ICUB_MODELS_BRANCH https://github.com/${DEPLOYMENT_REPOSITORY}.git
         cd icub-models
         export ICUB_MODELS_SOURCE_DIR=`pwd`
         cd ../

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
     # version as of 16 Septembter 2019, except for some dependencies that use
     # specific commits, more details are provided in inline comments
     - name: Generate models
-      if: ${{ github.event_name == 'not-a-real-event-name' }}
       run: |
         sudo apt-get update
         sudo apt-get install libeigen3-dev libace-dev libboost-dev libgsl0-dev libtinyxml-dev libxml2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,9 +155,8 @@ jobs:
         env
         # Build and run
         make VERBOSE=1
-        sudo cmake --build .
         ctest --output-on-failure
-        sudo cmake --build . --target copy-models-to-icub-models
+        cmake --build . --target copy-models-to-icub-models
         # Generate commit message 
         echo "Automatic build. GitHub Actions build: $GITHUB_RUN_ID" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "icub-model-generator commit:$GITHUB_SHA" >> ${GITHUB_WORKSPACE}/deploy_commit_message
@@ -165,6 +164,11 @@ jobs:
         echo "simmechanics-to-urdf commit:$SIMMECHANICS_TO_URDF_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "icub-main commit:$ICUB_MAIN_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+
+    - name: Check generated model diff
+      run: |
+        cd $ICUB_MODELS_SOURCE_DIR
+        git diff
 
     - name: Commit models
       if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,6 @@ jobs:
         export SIMMECHANICS_TO_URDF_COMMIT=`git rev-parse HEAD`
         sudo python setup.py install
         cd ${GITHUB_WORKSPACE}
-        # copy output folders and add the environment variable
-        git clone -b $ICUB_MODELS_BRANCH https://github.com/${DEPLOYMENT_REPOSITORY}.git ${ICUB_MODELS_SOURCE_DIR}
-        cd ${GITHUB_WORKSPACE}
         # get C++ dependencies and save their last commit SHA1 hash
         # ycm
         git clone https://github.com/robotology/ycm.git
@@ -151,11 +148,11 @@ jobs:
         mkdir build
         cd build
         cmake -DICUB_MODELS_SOURCE_DIR=$ICUB_MODELS_SOURCE_DIR  ..
-        # Print env to check if all env variables are still valid 
-        env
         # Build and run
         make VERBOSE=1
         ctest --output-on-failure
+        # Clone icub-models repo
+        git clone -b $ICUB_MODELS_BRANCH https://github.com/${DEPLOYMENT_REPOSITORY}.git ${ICUB_MODELS_SOURCE_DIR}
         cmake --build . --target copy-models-to-icub-models
         # Generate commit message 
         echo "Automatic build. GitHub Actions build: $GITHUB_RUN_ID" >> ${GITHUB_WORKSPACE}/deploy_commit_message

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,12 @@ jobs:
     - name: env_TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
       run: echo "${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}"
     - name: print_check
-      run: echo ${{ github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
-    - name: print_github ${{ toJSON(github) }}
+      run: echo ${{ startsWith(github.ref,env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT) }}
+    - name: print_check2
+      run: echo ${{ endsWith(github.ref,env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT) }}
+    - name: print_github ${{ toJSON(github.ref) }}
       run: echo "hello"
-    - name: print_github ${{ toJSON(env) }}
+    - name: print_github ${{ toJSON(env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT) }}
       run: echo "hello2"
     # Print environment variables to simplify development and debugging
     - name: Environment Variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,12 @@ jobs:
     - name: Environment Variables
       shell: bash
       run: env
-      
+  
+    - name: Deploy models (before)
+      if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
+      run: |
+        echo "Working!"
+
     # For all dependencies, we use fixed releases to avoid regression due to
     # changes in the dependencies. In particular, we use the latest released
     # version as of 16 Septembter 2019, except for some dependencies that use
@@ -175,7 +180,7 @@ jobs:
         echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Deploy models
-      if: github.event_name == 'push'
+      if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
         cat ${GITHUB_WORKSPACE}/deploy_commit_message
         export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       run: env
   
     - name: Deploy models (before)
-      if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
+      if: ${{ github.event_name == 'push' }}
       run: |
         echo "Working!"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
    
+    - name: ref
+      run: echo ${{ github.ref }}
+    - name: event_name
+      run: echo ${{ github.event_name }}
+    - name: env_TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
+      run: echo ${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,15 @@ jobs:
       run: echo ${{ github.event_name }}
     - name: env_TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
       run: echo ${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}
+    - name: print_check
+      run: echo ${{ github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
       shell: bash
       run: env
   
     - name: Deploy models (before)
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
         echo "Working!"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     # version as of 16 Septembter 2019, except for some dependencies that use
     # specific commits, more details are provided in inline comments
     - name: Generate models
+      if: ${{ github.event_name == 'not-a-real-event-name' }}
       run: |
         sudo apt-get update
         sudo apt-get install libeigen3-dev libace-dev libboost-dev libgsl0-dev libtinyxml-dev libxml2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
       run: echo "${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}"
     - name: print_check
       run: echo ${{ github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
-    - name: print_github
-      run: echo ${{ toJSON(github) }}
-    - name: print_env
-      run: echo ${{ toJSON(env) }}
+    - name: print_github ${{ toJSON(github) }}
+      run: echo "hello"
+    - name: print_github ${{ toJSON(env) }}
+      run: echo "hello2"
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ env:
   URDF_PARSER_PY_REPOSITORY_URL: "https://github.com/ros/urdf_parser_py.git"
   SIMMECHANICS_TO_URDF_REPOSITORY_URL: "https://github.com/robotology/simmechanics-to-urdf.git"
   DEPLOYMENT_REPOSITORY: "robotology/icub-models"
-  TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT: "refs/heads/test-gha-deploy"
+  TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT: "refs/heads/master"
   TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT: "https://github.com/robotology/icub-model-generator.git"
   BOT_USER_NAME: "LOC2Bot"
-  ICUB_MODELS_BRANCH: "test-gha-deploy-devel"
+  ICUB_MODELS_BRANCH: "devel"
   ICUB_MODELS_SOURCE_DIR: "/home/runner/work/icub-model-generator/icub-model-generator/icub-models"
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,7 @@ jobs:
         echo "icub-main commit:$ICUB_MAIN_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
-    - name: Check generated model diff
+    - name: Print generated models differences
       run: |
         cd $ICUB_MODELS_SOURCE_DIR
         git diff
@@ -178,9 +178,8 @@ jobs:
         echo "Commit committer is $GIT_COMMITTER_NAME (email: $GIT_COMMITTER_EMAIL)"
         echo "Commit author is $GIT_AUTHOR_NAME (email: $GIT_AUTHOR_EMAIL)"
         cd $ICUB_MODELS_SOURCE_DIR
-        pwd
-        git status
-        git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message
+        # See https://stackoverflow.com/a/32507305
+        git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message || echo "No changse in the icub-models branch, so no commit was done."
 
     - name: Push models
       uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Deploy models
-      if: github.event_name == 'push' && env.GITHUB_REF == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
+      if: github.event_name == 'push'
       run: |
         cat ${GITHUB_WORKSPACE}/deploy_commit_message
         export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         # Save the url of the repository and the user-name of the committ author
         export CURRENT_REPOSITORY_URL=`git remote get-url origin`
         # Start in the parent directory of icub-model-generator
+        pwd
         cd ..
         sudo apt-get install  --assume-yes --force-yes python-lxml python-yaml python-numpy python-setuptools
         # probably python on the path return a python interpreter and the find_package(PythonInterp) in CMake another,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       run: env
   
     - name: Deploy models (before)
-      if: ${{ github.event_name == "push" && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
+      if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
         echo "Working!"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         echo "Commit committer is $GIT_COMMITTER_NAME (email: $GIT_COMMITTER_EMAIL)"
         echo "Commit author is $GIT_AUTHOR_NAME (email: $GIT_AUTHOR_EMAIL)"
         cd $ICUB_MODELS_SOURCE_DIR
-        git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message --author "$COMMIT_AUTHOR"
+        git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Push models
       uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,20 +169,19 @@ jobs:
         echo "icub-main commit:$ICUB_MAIN_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
         echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
-    - name: Commit Models
+    - name: Commit models
       if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
-        cat ${GITHUB_WORKSPACE}/deploy_commit_message
-        export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"
-        cat $COMMIT_AUTHOR
+        export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $GITHUB_SHA)"
         cd $ICUB_MODELS_SOURCE_DIR
         git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message --author "$COMMIT_AUTHOR"
 
-    - name: Push Models
+    - name: Push models
       uses: ad-m/github-push-action@v0.6.0
+      if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       with:
         directory: ${{ env.ICUB_MODELS_SOURCE_DIR }}
         repository: ${{ env.DEPLOYMENT_REPOSITORY }}
         branch: ${{ env.ICUB_MODELS_BRANCH }}
-        token: ${{ secrets.BOT_TRIGGER_ROBOTOLOGY_DOCUMENTATION }}
+        github_token: ${{ secrets.BOT_TRIGGER_ROBOTOLOGY_DOCUMENTATION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         # Prepare icub-model-generator build
         mkdir build
         cd build
-        cmake -D ICUB_MODELS_SOURCE_DIR=$ICUB_MODELS_SOURCE_DIR  ..
+        cmake -DICUB_MODELS_SOURCE_DIR=$ICUB_MODELS_SOURCE_DIR  ..
         # Print env to check if all env variables are still valid 
         env
         # Build and run
@@ -177,6 +177,8 @@ jobs:
         echo "Commit committer is $GIT_COMMITTER_NAME (email: $GIT_COMMITTER_EMAIL)"
         echo "Commit author is $GIT_AUTHOR_NAME (email: $GIT_AUTHOR_EMAIL)"
         cd $ICUB_MODELS_SOURCE_DIR
+        pwd
+        git status
         git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Push models

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   URDF_PARSER_PY_REPOSITORY_URL: "https://github.com/ros/urdf_parser_py.git"
   SIMMECHANICS_TO_URDF_REPOSITORY_URL: "https://github.com/robotology/simmechanics-to-urdf.git"
   DEPLOYMENT_REPOSITORY_TOKEN: "github.com/robotology/icub-models.git"
-  TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT: "ref/heads/test-gha-deploy"
+  TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT: "refs/heads/test-gha-deploy"
   TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT: "https://github.com/robotology/icub-model-generator.git"
   BOT_USER_NAME: "LOC2Bot"
   ICUB_MODELS_BRANCH: "test-gha-deploy-devel"
@@ -44,7 +44,7 @@ jobs:
       run: env
   
     - name: Deploy models (before)
-      if: ${{ github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
+      if: ${{ github.event_name == "push" && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
         echo "Working!"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,29 +24,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
    
-    - name: ref
-      run: echo "${{ github.ref }}"
-    - name: event_name
-      run: echo ${{ github.event_name }}
-    - name: env_TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
-      run: echo "${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}"
-    - name: print_check
-      run: echo ${{ startsWith(github.ref,env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT) }}
-    - name: print_check2
-      run: echo ${{ endsWith(github.ref,env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT) }}
-    - name: print_github ${{ toJSON(github.ref) }}
-      run: echo "hello"
-    - name: print_github ${{ toJSON(env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT) }}
-      run: echo "hello2"
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
       shell: bash
       run: env
-  
-    - name: Deploy models (before)
-      if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
-      run: |
-        echo "Working!"
 
     # For all dependencies, we use fixed releases to avoid regression due to
     # changes in the dependencies. In particular, we use the latest released

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,4 +189,3 @@ jobs:
         repository: ${{ env.DEPLOYMENT_REPOSITORY }}
         branch: ${{ env.ICUB_MODELS_BRANCH }}
         github_token: ${{ secrets.BOT_TRIGGER_ROBOTOLOGY_DOCUMENTATION }}
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,13 @@ jobs:
     - name: Commit models
       if: ${{ github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
       run: |
-        export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $GITHUB_SHA)"
-        echo "Commit author is $COMMIT_AUTHOR"
+        # See https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables
+        export GIT_COMMITTER_NAME="$(git --no-pager show -s --format='%cn' $GITHUB_SHA)"
+        export GIT_AUTHOR_NAME="$(git --no-pager show -s --format='%an' $GITHUB_SHA)"
+        export GIT_COMMITTER_EMAIL="$(git --no-pager show -s --format='%ce' $GITHUB_SHA)"
+        export GIT_AUTHOR_EMAIL="$(git --no-pager show -s --format='%ae' $GITHUB_SHA)"
+        echo "Commit committer is $GIT_COMMITTER_NAME (email: $GIT_COMMITTER_EMAIL)"
+        echo "Commit author is $GIT_AUTHOR_NAME (email: $GIT_AUTHOR_EMAIL)"
         cd $ICUB_MODELS_SOURCE_DIR
         git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message --author "$COMMIT_AUTHOR"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
       run: echo "${{ env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT  }}"
     - name: print_check
       run: echo ${{ github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT }}
+    - name: print_github
+      run: echo ${{ toJSON(github) }}
+    - name: print_env
+      run: echo ${{ toJSON(env) }}
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,176 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  schedule:
+  # * is a special character in YAML so you have to quote this string
+  # Execute a "nightly" build at 2 AM UTC 
+  - cron:  '0 2 * * *'
+
+env:
+  URDF_PARSER_PY_REPOSITORY_URL: "https://github.com/ros/urdf_parser_py.git"
+  SIMMECHANICS_TO_URDF_REPOSITORY_URL: "https://github.com/robotology/simmechanics-to-urdf.git"
+  DEPLOYMENT_REPOSITORY_TOKEN: "github.com/robotology/icub-models.git"
+  TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT: "ref/heads/test-gha-deploy"
+  TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT: "https://github.com/robotology/icub-model-generator.git"
+  BOT_USER_NAME: "LOC2Bot"
+  ICUB_MODELS_BRANCH: "test-gha-deploy-devel"
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+   
+    # Print environment variables to simplify development and debugging
+    - name: Environment Variables
+      shell: bash
+      run: env
+      
+    # For all dependencies, we use fixed releases to avoid regression due to
+    # changes in the dependencies. In particular, we use the latest released
+    # version as of 16 Septembter 2019, except for some dependencies that use
+    # specific commits, more details are provided in inline comments
+    - name: Generate models
+      run: |
+        sudo apt-get update
+        sudo apt-get install libeigen3-dev 
+        # Save the url of the repository and the user-name of the committ author
+        export CURRENT_REPOSITORY_URL=`git remote get-url origin`
+        # Start in the parent directory of icub-model-generator
+        cd ..
+        sudo apt-get install  --assume-yes --force-yes python-lxml python-yaml python-numpy python-setuptools
+        # probably python on the path return a python interpreter and the find_package(PythonInterp) in CMake another,
+        # let's install both debian packages and pip packages to be sure 
+        sudo pip install lxml numpy pyyaml catkin_pkg
+        # install urdf_parser_py and save the last commit SHA1 hash
+        git clone $URDF_PARSER_PY_REPOSITORY_URL
+        cd urdf_parser_py
+        # workaround for https://github.com/robotology/simmechanics-to-urdf/issues/36
+        git checkout 31474b9baaf7c3845b40e5a9aa87d5900a2282c3
+        export URDF_PARSER_PY_COMMIT=`git rev-parse HEAD`
+        sudo python setup.py install
+        cd ../
+        # install simmechanics-to-urdf and save the last commit SHA1 hash
+        git clone $SIMMECHANICS_TO_URDF_REPOSITORY_URL
+        cd simmechanics-to-urdf
+        export SIMMECHANICS_TO_URDF_COMMIT=`git rev-parse HEAD`
+        sudo python setup.py install
+        cd ../
+        # copy output folders and add the environment variable
+        git clone -b $ICUB_MODELS_BRANCH https://$DEPLOYMENT_REPOSITORY_TOKEN
+        cd icub-models
+        export ICUB_MODELS_SOURCE_DIR=`pwd`
+        cd ../
+        # get C++ dependencies and save their last commit SHA1 hash
+        # ycm
+        git clone https://github.com/robotology/ycm.git
+        cd ycm
+        git checkout v0.11.3
+        mkdir build
+        cd build
+        cmake ..
+        sudo cmake --build . --target install
+        cd ../..
+        ## yarp
+        git clone https://github.com/robotology/yarp.git
+        cd yarp
+        git checkout v3.4.0
+        export YARP_COMMIT=`git rev-parse HEAD`
+        mkdir build
+        cd build
+        cmake -DCREATE_LIB_MATH:BOOL=ON ..
+        sudo cmake --build . --target install
+        cd ../..
+        ## icub-main
+        git clone https://github.com/robotology/icub-main.git
+        cd icub-main
+        git checkout v1.17.0
+        export ICUB_MAIN_COMMIT=`git rev-parse HEAD`
+        mkdir build
+        cd build
+        cmake ..
+        sudo cmake --build . --target install
+        cd ../..
+        ## orocos_kdl
+        git clone https://github.com/orocos/orocos_kinematics_dynamics
+        cd orocos_kinematics_dynamics/orocos_kdl
+        git checkout v1.4.0
+        mkdir build
+        cd build
+        cmake ..
+        sudo cmake --build . --target install
+        cd ../../..
+        ## console_bridge
+        git clone https://github.com/ros/console_bridge
+        cd console_bridge
+        # Go the commit of the 7th Septmber 2018 for
+        # console_bridge, urdfdom_headers and urdfdom, see
+        # https://travis-ci.org/robotology/icub-model-generator/builds/425819092?utm_source=github_status&utm_medium=notification
+        git checkout ad25f7307da76be2857545e7e5c2a20727eee542
+        mkdir build
+        cd build
+        cmake ..
+        sudo cmake --build . --target install
+        cd ../..
+        # urdfdom_headers
+        git clone https://github.com/ros/urdfdom_headers
+        cd urdfdom_headers
+        git checkout e7e0972a4617b8a5df7a274ea3ba3b92e3895a35
+        mkdir build
+        cd build
+        cmake ..
+        sudo cmake --build . --target install
+        cd ../..
+        # urdfdom
+        git clone https://github.com/ros/urdfdom
+        cd urdfdom
+        git checkout 06f5f9bc34f09b530d9f3743cb0516934625da54
+        mkdir build
+        cd build
+        cmake  ..
+        sudo cmake --build . --target install
+        cd ../..
+        ## idyntree
+        git clone https://github.com/robotology/idyntree.git
+        cd idyntree
+        git checkout v0.11.1
+        export IDYNTREE_COMMIT=`git rev-parse HEAD`
+        mkdir build
+        cd build
+        cmake -DIDYNTREE_USES_KDL:BOOL=ON ..
+        sudo cmake --build . --target install
+        cd ../..
+        # Install sdformat
+        sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
+        wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+        sudo apt-get update
+        sudo apt-get install --assume-yes --force-yes libsdformat6-dev
+        # Prepare icub-model-generator build
+        cd icub-model-generator
+        mkdir build
+        cd build
+        cmake -D ICUB_MODELS_SOURCE_DIR=$ICUB_MODELS_SOURCE_DIR  ..
+        # Print env to check if all env variables are still valid 
+        env
+        # Build and run
+        make VERBOSE=1
+        sudo cmake --build .
+        ctest --output-on-failure
+        sudo cmake --build . --target copy-models-to-icub-models
+        # Generate commit message 
+        echo "Automatic build. GitHub Actions build: $GITHUB_RUN_ID" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "icub-model-generator commit:$GITHUB_SHA" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "urdf_parser_py commit:$URDF_PARSER_PY_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "simmechanics-to-urdf commit:$SIMMECHANICS_TO_URDF_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "icub-main commit:$ICUB_MAIN_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+        echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
+
+    - name: Deploy models
+      if: github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
+      run: |
+        cat ${GITHUB_WORKSPACE}/deploy_commit_message
+        export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"
+        cat $COMMIT_AUTHOR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,3 +189,4 @@ jobs:
         repository: ${{ env.DEPLOYMENT_REPOSITORY }}
         branch: ${{ env.ICUB_MODELS_BRANCH }}
         github_token: ${{ secrets.BOT_TRIGGER_ROBOTOLOGY_DOCUMENTATION }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,7 @@ jobs:
         # Save the url of the repository and the user-name of the committ author
         export CURRENT_REPOSITORY_URL=`git remote get-url origin`
         # Start in the parent directory of icub-model-generator
-        pwd
-        cd ..
+        cd ${GITHUB_WORKSPACE}
         sudo apt-get install  --assume-yes --force-yes python-lxml python-yaml python-numpy python-setuptools
         # probably python on the path return a python interpreter and the find_package(PythonInterp) in CMake another,
         # let's install both debian packages and pip packages to be sure 
@@ -54,17 +53,16 @@ jobs:
         git checkout 31474b9baaf7c3845b40e5a9aa87d5900a2282c3
         export URDF_PARSER_PY_COMMIT=`git rev-parse HEAD`
         sudo python setup.py install
-        cd ../
+        cd ${GITHUB_WORKSPACE}
         # install simmechanics-to-urdf and save the last commit SHA1 hash
         git clone $SIMMECHANICS_TO_URDF_REPOSITORY_URL
         cd simmechanics-to-urdf
         export SIMMECHANICS_TO_URDF_COMMIT=`git rev-parse HEAD`
         sudo python setup.py install
-        cd ../
+        cd ${GITHUB_WORKSPACE}
         # copy output folders and add the environment variable
         git clone -b $ICUB_MODELS_BRANCH https://github.com/${DEPLOYMENT_REPOSITORY}.git ${ICUB_MODELS_SOURCE_DIR}
-        cd  ${ICUB_MODELS_SOURCE_DIR}
-        cd ../
+        cd ${GITHUB_WORKSPACE}
         # get C++ dependencies and save their last commit SHA1 hash
         # ycm
         git clone https://github.com/robotology/ycm.git
@@ -74,7 +72,7 @@ jobs:
         cd build
         cmake ..
         sudo cmake --build . --target install
-        cd ../..
+        cd ${GITHUB_WORKSPACE}
         ## yarp
         git clone https://github.com/robotology/yarp.git
         cd yarp
@@ -84,7 +82,7 @@ jobs:
         cd build
         cmake -DCREATE_LIB_MATH:BOOL=ON ..
         sudo cmake --build . --target install
-        cd ../..
+        cd ${GITHUB_WORKSPACE}
         ## icub-main
         git clone https://github.com/robotology/icub-main.git
         cd icub-main
@@ -94,7 +92,7 @@ jobs:
         cd build
         cmake ..
         sudo cmake --build . --target install
-        cd ../..
+        cd ${GITHUB_WORKSPACE}
         ## orocos_kdl
         git clone https://github.com/orocos/orocos_kinematics_dynamics
         cd orocos_kinematics_dynamics/orocos_kdl
@@ -103,7 +101,7 @@ jobs:
         cd build
         cmake ..
         sudo cmake --build . --target install
-        cd ../../..
+        cd ${GITHUB_WORKSPACE}
         ## console_bridge
         git clone https://github.com/ros/console_bridge
         cd console_bridge
@@ -115,7 +113,7 @@ jobs:
         cd build
         cmake ..
         sudo cmake --build . --target install
-        cd ../..
+        cd ${GITHUB_WORKSPACE}
         # urdfdom_headers
         git clone https://github.com/ros/urdfdom_headers
         cd urdfdom_headers
@@ -124,7 +122,7 @@ jobs:
         cd build
         cmake ..
         sudo cmake --build . --target install
-        cd ../..
+        cd ${GITHUB_WORKSPACE}
         # urdfdom
         git clone https://github.com/ros/urdfdom
         cd urdfdom
@@ -133,7 +131,7 @@ jobs:
         cd build
         cmake  ..
         sudo cmake --build . --target install
-        cd ../..
+        cd ${GITHUB_WORKSPACE}
         ## idyntree
         git clone https://github.com/robotology/idyntree.git
         cd idyntree
@@ -143,14 +141,13 @@ jobs:
         cd build
         cmake -DIDYNTREE_USES_KDL:BOOL=ON ..
         sudo cmake --build . --target install
-        cd ../..
+        cd ${GITHUB_WORKSPACE}
         # Install sdformat
         sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
         wget https://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
         sudo apt-get update
         sudo apt-get install --assume-yes --force-yes libsdformat6-dev
         # Prepare icub-model-generator build
-        cd icub-model-generator
         mkdir build
         cd build
         cmake -D ICUB_MODELS_SOURCE_DIR=$ICUB_MODELS_SOURCE_DIR  ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
         echo "Commit author is $GIT_AUTHOR_NAME (email: $GIT_AUTHOR_EMAIL)"
         cd $ICUB_MODELS_SOURCE_DIR
         # See https://stackoverflow.com/a/32507305
-        git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message || echo "No changse in the icub-models branch, so no commit was done."
+        git commit -a -F ${GITHUB_WORKSPACE}/deploy_commit_message || echo "No changes in the icub-models branch, so no commit was done."
 
     - name: Push models
       uses: ad-m/github-push-action@v0.6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ env:
   TRIGGERING_REPOSITORY_URL_VALID_FOR_DEPLOYMENT: "https://github.com/robotology/icub-model-generator.git"
   BOT_USER_NAME: "LOC2Bot"
   ICUB_MODELS_BRANCH: "test-gha-deploy-devel"
-  ICUB_MODELS_SOURCE_DIR: ${{ env.github_workspace }}/icub-models
+  ICUB_MODELS_SOURCE_DIR: "~/icub-models"
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,8 @@ jobs:
         sudo python setup.py install
         cd ../
         # copy output folders and add the environment variable
-        git clone -b $ICUB_MODELS_BRANCH https://github.com/${DEPLOYMENT_REPOSITORY}.git
-        cd icub-models
-        export ICUB_MODELS_SOURCE_DIR=`pwd`
+        git clone -b $ICUB_MODELS_BRANCH https://github.com/${DEPLOYMENT_REPOSITORY}.git ${ICUB_MODELS_SOURCE_DIR}
+        cd  ${ICUB_MODELS_SOURCE_DIR}
         cd ../
         # get C++ dependencies and save their last commit SHA1 hash
         # ycm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,7 +169,7 @@ jobs:
         echo "idyntree commit:$IDYNTREE_COMMIT" >> ${GITHUB_WORKSPACE}/deploy_commit_message
 
     - name: Deploy models
-      if: github.event_name == 'push' && github.ref == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
+      if: github.event_name == 'push' && env.GITHUB_REF == env.TRIGGERING_BRANCH_VALID_FOR_DEPLOYMENT 
       run: |
         cat ${GITHUB_WORKSPACE}/deploy_commit_message
         export COMMIT_AUTHOR="$(git --no-pager show -s --format='%an <%ae>' $TRAVIS_COMMIT)"

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -2,11 +2,11 @@
 robotName: iCub
 
 # Model base origin
-originXYZ: [0.0,0.0,0.63]
+originXYZ: [0.0,0.0,100.63]
 originRPY: [0.0,0.0,3.14]
 
 # Meshes options
-scale: "0.001 0.001 0.001"
+scale: "1.0 1.0 1.0"
 forcelowercase: Yes
 @MESH_FILE_FORMAT@
 

--- a/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
+++ b/simmechanics/data/icub2_5/ICUB_2-5_BB_simmechanics_options.yaml.in
@@ -2,11 +2,11 @@
 robotName: iCub
 
 # Model base origin
-originXYZ: [0.0,0.0,100.63]
+originXYZ: [0.0,0.0,0.63]
 originRPY: [0.0,0.0,3.14]
 
 # Meshes options
-scale: "1.0 1.0 1.0"
+scale: "0.001 0.001 0.001"
 forcelowercase: Yes
 @MESH_FILE_FORMAT@
 

--- a/simmechanics/data/icub2_5/adjust_com_for_model_without_backpack.py
+++ b/simmechanics/data/icub2_5/adjust_com_for_model_without_backpack.py
@@ -24,8 +24,7 @@ for inertial in link_chest.getiterator('inertial'):
 if( origin_chest.get('xyz') != '0.000188619190735 0.073091 -0.047238'):
     print("Warning: unexpected com for the chest ",origin_chest.get('xyz'));
     
-# origin_chest.set('xyz','0.000188619190735 0.023091 -0.013238');
-origin_chest.set('xyz','100.0 200.0 3.000');
+origin_chest.set('xyz','0.000188619190735 0.023091 -0.013238');
 
 # Save to file (see http://stackoverflow.com/questions/12517451/python-automatically-creating-directories-with-file-output)
 if not os.path.exists(os.path.dirname(args.output_urdf)):

--- a/simmechanics/data/icub2_5/adjust_com_for_model_without_backpack.py
+++ b/simmechanics/data/icub2_5/adjust_com_for_model_without_backpack.py
@@ -24,8 +24,9 @@ for inertial in link_chest.getiterator('inertial'):
 if( origin_chest.get('xyz') != '0.000188619190735 0.073091 -0.047238'):
     print("Warning: unexpected com for the chest ",origin_chest.get('xyz'));
     
-origin_chest.set('xyz','0.000188619190735 0.023091 -0.013238');
-    
+# origin_chest.set('xyz','0.000188619190735 0.023091 -0.013238');
+origin_chest.set('xyz','100.0 200.0 3.000');
+
 # Save to file (see http://stackoverflow.com/questions/12517451/python-automatically-creating-directories-with-file-output)
 if not os.path.exists(os.path.dirname(args.output_urdf)):
     try:


### PR DESCRIPTION
For some reason, the Travis CI of this repo is still on travis-ci.org, but as soon as it will be migrate to travis-ci.com we will be subject to all the limitations mentioned in https://github.com/robotology/icub-model-generator/issues/158 . 

To avoid being blocked, I migrate the CI for model generation to use GitHub Actions. I already tested that the deploy to the icub-models repo is working correctly by pushing on the test branch https://github.com/robotology/icub-models/tree/test-gha-deploy-devel, see for example https://github.com/robotology/icub-models/commit/c3478cae9550c9d57abe63aab848be91b6278018 . I also tested that CI does not fail if no change is present. 

The history of the PR is messy, but I will merge with squash. Some parts of the scripts are still messy, but they will be simplified as soon as we fix https://github.com/robotology/icub-model-generator/issues/161 .