### PR TITLE
icub3: fix wrongly exported weights for feet

### DIFF
--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -313,6 +313,7 @@ assignedMasses:
   r_lower_leg: 4.59072
   r_ankle_1: 1.80595
   r_ankle_2: 1.06976
+  r_foot_rear: 0.18484137
   l_foot_rear: 0.18460842
   l_foot_front: 0.18507432
   # It fixes the wrong mass exported after shrinkwrap

--- a/simmechanics/data/icub3/ICUB_3_all_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options.yaml
@@ -313,8 +313,8 @@ assignedMasses:
   r_lower_leg: 4.59072
   r_ankle_1: 1.80595
   r_ankle_2: 1.06976
-  r_foot_rear: 0.728095
-  r_foot_front: 0.723938
+  l_foot_rear: 0.18460842
+  l_foot_front: 0.18507432
   # It fixes the wrong mass exported after shrinkwrap
   head: 1.955
 assignedInertias:

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml
@@ -313,6 +313,7 @@ assignedMasses:
   r_lower_leg: 4.59072
   r_ankle_1: 1.80595
   r_ankle_2: 1.06976
+  r_foot_rear: 0.18484137
   l_foot_rear: 0.18460842
   l_foot_front: 0.18507432
   # It fixes the wrong mass exported after shrinkwrap

--- a/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml
+++ b/simmechanics/data/icub3/ICUB_3_all_options_gazebo.yaml
@@ -313,8 +313,8 @@ assignedMasses:
   r_lower_leg: 4.59072
   r_ankle_1: 1.80595
   r_ankle_2: 1.06976
-  r_foot_rear: 0.728095
-  r_foot_front: 0.723938
+  l_foot_rear: 0.18460842
+  l_foot_front: 0.18507432
   # It fixes the wrong mass exported after shrinkwrap
   head: 1.955
 assignedInertias:

--- a/simmechanics/data/icub3/ICUB_3_leftleg_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_leftleg_options.yaml
@@ -94,6 +94,9 @@ forceTorqueSensors:
           <yarpConfigurationFile>model://iCub/conf_icub3/FT/gazebo_icub_left_foot_rear_ft.ini</yarpConfigurationFile>
         </plugin>
 
+assignedMasses:
+  l_foot_rear: 0.18460842
+  l_foot_front: 0.18507432
 reverseRotationAxis:
     l_ankle_pitch
 

--- a/simmechanics/data/icub3/ICUB_3_rightleg_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_rightleg_options.yaml
@@ -106,8 +106,6 @@ assignedMasses:
   r_lower_leg: 4.59072
   r_ankle_1: 1.80595
   r_ankle_2: 1.06976
-  r_foot_rear: 0.728095
-  r_foot_front: 0.723938
 
 assignedInertias:
   # It fixes the wrong inertias exported after shrinkwrap

--- a/simmechanics/data/icub3/ICUB_3_rightleg_options.yaml
+++ b/simmechanics/data/icub3/ICUB_3_rightleg_options.yaml
@@ -106,6 +106,7 @@ assignedMasses:
   r_lower_leg: 4.59072
   r_ankle_1: 1.80595
   r_ankle_2: 1.06976
+  r_foot_rear: 0.18484137
 
 assignedInertias:
   # It fixes the wrong inertias exported after shrinkwrap


### PR DESCRIPTION
`l_foot_rear` and `l_foot_front` seems to be wrongly exported in the simmechanics xml, the same for `r_foot_rear`

Please review code